### PR TITLE
Introduce --cocoapods option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## master
+* Introduce `--cocoapods` option  
+  [Toshihiro Suzuki](https://github.com/toshi0383)
+  [#7](https://github.com/toshi0383/xcconfig-extractor/pull/7)
+
 ## 0.2.0
 
 * Rename `trim-duplicates` to `--no-trim-duplicates`  

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Make sure you setup each configurations correctly on Xcode.
 Options:
     --no-trim-duplicates [default: false] - Don't extract duplicated lines to common xcconfig files, simply map each buildSettings to one file.
     --no-edit-pbxproj [default: false] - Do not modify pbxproj.
+    --cocoapods [default: false] - `#include` CocoaPods generated xcconfigs.
 ```
 
 # TODOs

--- a/Sources/xcconfig-extractor/Config.swift
+++ b/Sources/xcconfig-extractor/Config.swift
@@ -1,0 +1,17 @@
+//
+//  Config.swift
+//  xcconfig-extractor
+//
+//  Created by Toshihiro Suzuki on 2017/04/30.
+//  Copyright © 2017 Toshihiro Suzuki. All rights reserved.
+//
+
+import Foundation
+
+struct Config {
+    static let version = "0.2.0"
+    let isCocoaPods: Bool
+    init(isCocoaPods: Bool) {
+        self.isCocoaPods = isCocoaPods
+    }
+}

--- a/Sources/xcconfig-extractor/ResultFormatter.swift
+++ b/Sources/xcconfig-extractor/ResultFormatter.swift
@@ -1,0 +1,30 @@
+//
+//  ResultFormatter.swift
+//  xcconfig-extractor
+//
+//  Created by Toshihiro Suzuki on 2017/04/30.
+//  Copyright © 2017 Toshihiro Suzuki. All rights reserved.
+//
+
+import Foundation
+
+class ResultFormatter {
+    let config: Config
+    init(config: Config) {
+        self.config = config
+    }
+    private func header(targetName: String?, configurationName: String?) -> [String] {
+        let signature = "// Generated using xcconfig-extractor \(Config.version) by Toshihiro Suzuki - https://github.com/toshi0383/xcconfig-extractor"
+        if config.isCocoaPods {
+            if let targetName = targetName, let configurationName = configurationName?.lowercased() {
+                let cocoapods = "#include \"../Pods/Target Support Files/Pods-\(targetName)/Pods-\(targetName).\(configurationName).xcconfig\""
+                return [signature, cocoapods]
+            }
+        }
+        return [signature]
+    }
+    func format(result: ResultObject, includes: [String] = []) -> [String] {
+        return header(targetName: result.targetName, configurationName: result.configurationName)
+            + includes.map {"#include \"\($0)\""} + result.settings + ["\n"]
+    }
+}

--- a/Sources/xcconfig-extractor/ResultObject.swift
+++ b/Sources/xcconfig-extractor/ResultObject.swift
@@ -1,0 +1,30 @@
+//
+//  ResultObject.swift
+//  xcconfig-extractor
+//
+//  Created by Toshihiro Suzuki on 2017/04/30.
+//  Copyright © 2017 Toshihiro Suzuki. All rights reserved.
+//
+
+import Foundation
+import PathKit
+
+class ResultObject: Equatable {
+    let path: Path
+    var settings: [String]
+    let targetName: String?
+    let configurationName: String?
+    init(path: Path, settings: [String], targetName: String? = nil, configurationName: String? = nil) {
+        self.path = path
+        self.settings = settings
+        self.targetName = targetName
+        self.configurationName = configurationName
+    }
+}
+func ==(lhs: ResultObject, rhs: ResultObject) -> Bool {
+    guard lhs.path == rhs.path else { return false }
+    guard lhs.settings == rhs.settings else { return false }
+    guard lhs.targetName == rhs.targetName else { return false }
+    guard lhs.configurationName == rhs.configurationName else { return false }
+    return true
+}


### PR DESCRIPTION
Added `--cocoapods` option to `#include` CocoaPods generated xcconfigs automatically.
```
$ xcconfig-extractor --cocoapods library.xcodeproj configs
$ grep include configs/*
configs/library-Debug.xcconfig:#include "../Pods/Target Support Files/Pods-library/Pods-library.debug.xcconfig"
configs/library-Release.xcconfig:#include "../Pods/Target Support Files/Pods-library/Pods-library.release.xcconfig"
configs/libraryTests-Debug.xcconfig:#include "../Pods/Target Support Files/Pods-libraryTests/Pods-libraryTests.debug.xcconfig"
configs/libraryTests-Release.xcconfig:#include "../Pods/Target Support Files/Pods-libraryTests/Pods-libraryTests.release.xcconfig"
```