### PR TITLE
Use `firstIndex(of:)` instead of `index(of:)`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/tuist/XcodeProj",
         "state": {
           "branch": null,
-          "revision": "300c3a1b468bd413a15e1f63b196dc6113bc62fb",
-          "version": "7.0.1"
+          "revision": "aefcbf59cea5b0831837ed2f385e6dfd80d82cc9",
+          "version": "7.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version:4.2
-// Managed by ice
+// swift-tools-version:5.1
 
 import PackageDescription
 
@@ -9,9 +8,9 @@ let package = Package(
         .executable(name: "xcconfig-extractor", targets: ["xcconfig-extractor"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/kylef/PathKit", from: "1.0.0"),
-        .package(url: "https://github.com/kylef/Commander", from: "0.9.0"),
-        .package(url: "https://github.com/tuist/XcodeProj", from: "7.0.1"),
+        .package(url: "https://github.com/kylef/PathKit", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/kylef/Commander", .upToNextMajor(from: "0.9.0")),
+        .package(url: "https://github.com/tuist/XcodeProj", .upToNextMajor(from: "7.1.0")),
     ],
     targets: [
         .target(name: "xcconfig-extractor", dependencies: ["Utilities", "PathKit", "Commander", "XcodeProj"]),

--- a/Sources/xcconfig-extractor/main.swift
+++ b/Sources/xcconfig-extractor/main.swift
@@ -125,11 +125,11 @@ let main = command(
             let filtered = targetResults
                 .filter { $0.path.components.last!.contains("-\(configurationName).xcconfig") }
             let common: [String] = commonElements(filtered.map { $0.settings })
-            let idx = baseResults.index { $0.configurationName == configurationName }!
+            let idx = baseResults.firstIndex { $0.configurationName == configurationName }!
             baseResults[idx].settings = distinctArray(common + baseResults[idx].settings)
             // Write Upper Layer Configs (e.g. App-Debug.xcconfig, AppTests-Debug.xcconfig)
             for r in filtered {
-                let idx = targetResults.index(of: r)!
+                let idx = targetResults.firstIndex(of: r)!
                 targetResults[idx].settings = r.settings - common
             }
         }
@@ -142,7 +142,7 @@ let main = command(
             let r = ResultObject(path: targetConfigPath, settings: common)
             try write(to: r.path, lines: formatter.format(result: r))
             for r in filtered {
-                let idx = targetResults.index(of: r)!
+                let idx = targetResults.firstIndex(of: r)!
                 targetResults[idx].settings = r.settings - common
                 targetResults[idx].includes += [targetConfigPath.lastComponent]
                 try write(to: r.path, lines: formatter.format(result: targetResults[idx]))


### PR DESCRIPTION
Please check #22 first. This pr was made following #22 .

[`index(of:)` is deprecated on swift 5.0.](https://developer.apple.com/documentation/swift/array/3126950-index)